### PR TITLE
Fix/manifest v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,12 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "No OSU Profile Picture",
   "version": "2.0",
   "description": "Removes profile pictures from the Rankings and more.",
-  "permissions": [
-    "storage",
-    "activeTab",
-    "*://osu.ppy.sh/*"
-  ],
+  "permissions": ["storage", "scripting", "activeTab"],
+  "host_permissions": ["*://osu.ppy.sh/*"],
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "content_scripts": [
     {
@@ -17,7 +14,7 @@
       "js": ["content/remove.js"]
     }
   ],
-  "browser_action": {
+  "action": {
     "default_popup": "options/options.html",
     "default_icon": {
       "16": "icons/icon16.png",

--- a/options/options.html
+++ b/options/options.html
@@ -45,7 +45,6 @@
       </div>
     </label>
   </div>
-  <script src="../lib/browser-polyfill.js"></script>
   <script src="options.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Migrated the extension to `manifest_version: 3` and resolved a runtime error related to a deprecated script in `options.html`.
Closes #7