### PR TITLE
refactor: replace DOM iteration with CSS injection, extend target URLs

### DIFF
--- a/content/remove.js
+++ b/content/remove.js
@@ -1,4 +1,11 @@
-const targetURL = "https://osu.ppy.sh/rankings";
+const targetURLs = [
+  "https://osu.ppy.sh/rankings",
+  "https://osu.ppy.sh/beatmapsets",
+  "https://osu.ppy.sh/scores",
+  "https://osu.ppy.sh/multiplayer",
+  "https://osu.ppy.sh/seasons",
+  "https://osu.ppy.sh/home/friends"
+];
 
 let currentSettings = {
   removeTeams: false,
@@ -7,7 +14,7 @@ let currentSettings = {
 };
 
 function isOnTargetURL() {
-  return window.location.href.startsWith(targetURL);
+  return targetURLs.some(url => window.location.href.startsWith(url));
 }
 
 function toggleElementsByClass(className, shouldHide) {
@@ -41,11 +48,16 @@ function toggleRankChangeColumns(shouldHide) {
 function runRemovals() {
   if (!isOnTargetURL()) return;
 
+  const href = window.location.href;
+  const isRankings = href.startsWith("https://osu.ppy.sh/rankings");
+
   toggleElementsByClass(".flag-team", currentSettings.removeTeams);
 
-  toggleRankChangeColumns(currentSettings.removeRankChanges);
-
-  toggleElementsByClass(".flag-country:not(.flag-country--flat)", currentSettings.removeCountry);
+  if (isRankings) {
+    const isGlobalRanking = href.startsWith("https://osu.ppy.sh/rankings/osu/global");
+    toggleRankChangeColumns(currentSettings.removeRankChanges && isGlobalRanking);
+    toggleElementsByClass(".flag-country:not(.flag-country--flat)", currentSettings.removeCountry);
+  }
 }
 
 function loadSettings(callback) {
@@ -62,7 +74,12 @@ function loadSettings(callback) {
   );
 }
 
-loadSettings(runRemovals);
+loadSettings(() => {
+  runRemovals();
+  if (window.location.href.includes("/rankings/ranked-play/")) {
+    setTimeout(runRemovals, 1000);
+  }
+});
 
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area !== 'local') return;
@@ -101,5 +118,9 @@ document.addEventListener("click", e => {
     [100, 300, 800].forEach(delay =>
       setTimeout(runRemovals, delay)
     );
+
+    if (window.location.href.includes("/rankings/ranked-play/")) {
+      setTimeout(runRemovals, 1000);
+    }
   }
 });

--- a/content/remove.js
+++ b/content/remove.js
@@ -4,7 +4,8 @@ const targetURLs = [
   "https://osu.ppy.sh/scores",
   "https://osu.ppy.sh/multiplayer",
   "https://osu.ppy.sh/seasons",
-  "https://osu.ppy.sh/home/friends"
+  "https://osu.ppy.sh/home/friends",
+  "https://osu.ppy.sh/users/"
 ];
 
 let currentSettings = {
@@ -72,9 +73,10 @@ function runRemovals() {
 
   const href = window.location.href;
   const isRankings = href.startsWith("https://osu.ppy.sh/rankings");
+  const isUserPage = href.startsWith("https://osu.ppy.sh/users/");
 
   // .flag-team — via global CSS (no MutationObserver or setTimeout hacks needed)
-  setCSSRule('flagTeam', '.flag-team', currentSettings.removeTeams);
+  setCSSRule('flagTeam', '.flag-team', currentSettings.removeTeams && !isUserPage);
 
   if (isRankings) {
     const isGlobalRanking = href.startsWith("https://osu.ppy.sh/rankings/osu/global");

--- a/content/remove.js
+++ b/content/remove.js
@@ -17,12 +17,33 @@ function isOnTargetURL() {
   return targetURLs.some(url => window.location.href.startsWith(url));
 }
 
-function toggleElementsByClass(className, shouldHide) {
-  const elements = document.querySelectorAll(className);
-  elements.forEach(el => {
-    el.style.display = shouldHide ? 'none' : '';
-  });
+// --- CSS injection instead of manually iterating over elements ---
+
+const styleEl = document.createElement('style');
+document.head.appendChild(styleEl);
+const sheet = styleEl.sheet;
+
+// Store rule indexes by selector key
+const ruleIndexes = {};
+
+function setCSSRule(key, selector, shouldHide) {
+  // Remove old rule if one exists
+  if (ruleIndexes[key] !== undefined) {
+    sheet.deleteRule(ruleIndexes[key]);
+    delete ruleIndexes[key];
+    // After deletion, indexes shift — recalculate all stored ones
+    Object.keys(ruleIndexes).forEach(k => {
+      if (ruleIndexes[k] > ruleIndexes[key]) ruleIndexes[k]--;
+    });
+  }
+
+  if (shouldHide) {
+    const idx = sheet.insertRule(`${selector} { display: none !important; }`, sheet.cssRules.length);
+    ruleIndexes[key] = idx;
+  }
 }
+
+// --- Logic for hiding rank-change columns (kept via style, because colspan is needed) ---
 
 function toggleRankChangeColumns(shouldHide) {
   const selectors = [
@@ -45,20 +66,27 @@ function toggleRankChangeColumns(shouldHide) {
   });
 }
 
+
 function runRemovals() {
   if (!isOnTargetURL()) return;
 
   const href = window.location.href;
   const isRankings = href.startsWith("https://osu.ppy.sh/rankings");
 
-  toggleElementsByClass(".flag-team", currentSettings.removeTeams);
+  // .flag-team — via global CSS (no MutationObserver or setTimeout hacks needed)
+  setCSSRule('flagTeam', '.flag-team', currentSettings.removeTeams);
 
   if (isRankings) {
     const isGlobalRanking = href.startsWith("https://osu.ppy.sh/rankings/osu/global");
     toggleRankChangeColumns(currentSettings.removeRankChanges && isGlobalRanking);
-    toggleElementsByClass(".flag-country:not(.flag-country--flat)", currentSettings.removeCountry);
+    // .flag-country — also via CSS
+    setCSSRule('flagCountry', '.flag-country:not(.flag-country--flat)', currentSettings.removeCountry);
+  } else {
+    // If navigated away from the rankings page — remove the country rule
+    setCSSRule('flagCountry', '.flag-country:not(.flag-country--flat)', false);
   }
 }
+
 
 function loadSettings(callback) {
   chrome.storage.local.get(
@@ -93,21 +121,27 @@ chrome.storage.onChanged.addListener((changes, area) => {
   }
 });
 
-let observerTimeout;
+// --- MutationObserver only for toggleRankChangeColumns (colspan logic) ---
+// .flag-team and .flag-country no longer need manual tracking — CSS will apply to new nodes automatically
+
+let observerTimeout = null;
 
 const observer = new MutationObserver(() => {
   if (observerTimeout) return;
-
   observerTimeout = setTimeout(() => {
-    runRemovals();
+    // Only needed for rank-change columns, which can't be covered by pure CSS
+    const href = window.location.href;
+    if (href.startsWith("https://osu.ppy.sh/rankings")) {
+      const isGlobalRanking = href.startsWith("https://osu.ppy.sh/rankings/osu/global");
+      toggleRankChangeColumns(currentSettings.removeRankChanges && isGlobalRanking);
+    }
     observerTimeout = null;
   }, 200);
 });
 
-observer.observe(document.body, {
-  childList: true,
-  subtree: true
-});
+observer.observe(document.body, { childList: true, subtree: true });
+
+// --- Navigation (SPA) ---
 
 ["popstate", "hashchange"].forEach(evt =>
   window.addEventListener(evt, runRemovals)


### PR DESCRIPTION
1. Extended target URL scope
Single targetURL = ".../rankings" → array targetURLs covering 6 pages (beatmapsets, scores, multiplayer, seasons, friends).
2. CSS injection instead of DOM iteration for .flag-team and .flag-country
toggleElementsByClass() removed. Both selectors now controlled via sheet.insertRule/deleteRule — rules apply to future DOM nodes automatically, no race condition against React re-renders.
3. toggleRankChangeColumns scoped to global ranking only
Previously fired on any /rankings page. Now checks isGlobalRanking (/rankings/osu/global) before applying colspan logic.
4. Country flag rule resets on non-rankings pages
Old version never called toggleElementsByClass(..., false) when navigating away. Now setCSSRule('flagCountry', ..., false) is explicitly called outside rankings context.
5. MutationObserver scope reduced
Observer no longer calls full runRemovals(). Now only calls toggleRankChangeColumns — the one case CSS can't cover (colspan attribute). Teams and country flags are handled passively by CSS.

TLDR: Most of the changes are due to /rankings/ranked-play/ being a pain —
it loads differently from every other rankings page, so the logic needed
a significant rework to handle it properly. Also fixed a bug where
rank-change columns weren't being hidden correctly.

If you don't want to deal with any of this, you can use commit 7f459f3
from my branch which keeps the old logic, just note that team hiding
will break when navigating from another tab via SPA (MutationObserver issue)